### PR TITLE
feat: 支持发送消息指定 client_msg_no

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ logs/
 
 wukongimdata/
 tsdddata/
+
+# Local Figma exports and caches
+**/.figma-cache/
+**/figma-cache/
+**/my-figma/
+**/docs/figma/

--- a/config/msg.go
+++ b/config/msg.go
@@ -796,14 +796,15 @@ type UserBaseVo struct {
 
 // MsgSendReq 发送消息请求
 type MsgSendReq struct {
-	Header      MsgHeader `json:"header"`       // 消息头
-	Setting     uint8     `json:"setting"`      // setting
-	FromUID     string    `json:"from_uid"`     // 模拟发送者的UID
-	ChannelID   string    `json:"channel_id"`   // 频道ID
-	ChannelType uint8     `json:"channel_type"` // 频道类型
-	StreamNo    string    `json:"stream_no"`    // 消息流号
-	Subscribers []string  `json:"subscribers"`  // 订阅者 如果此字段有值，表示消息只发给指定的订阅者
-	Payload     []byte    `json:"payload"`      // 消息内容
+	Header      MsgHeader `json:"header"`                  // 消息头
+	Setting     uint8     `json:"setting"`                 // setting
+	ClientMsgNo string    `json:"client_msg_no,omitempty"` // 客户端消息唯一编号，用于发送幂等
+	FromUID     string    `json:"from_uid"`                // 模拟发送者的UID
+	ChannelID   string    `json:"channel_id"`              // 频道ID
+	ChannelType uint8     `json:"channel_type"`            // 频道类型
+	StreamNo    string    `json:"stream_no"`               // 消息流号
+	Subscribers []string  `json:"subscribers"`             // 订阅者 如果此字段有值，表示消息只发给指定的订阅者
+	Payload     []byte    `json:"payload"`                 // 消息内容
 }
 
 type MsgSendResp struct {

--- a/config/msg_test.go
+++ b/config/msg_test.go
@@ -1,11 +1,84 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
 func TestSetting(t *testing.T) {
 	setting := SettingFromUint8(160)
 	fmt.Println(setting.Signal)
+}
+
+func TestMsgSendReqClientMsgNoJSON(t *testing.T) {
+	req := MsgSendReq{
+		ClientMsgNo: "hall_reply_001",
+		FromUID:     "robot",
+		ChannelID:   "group",
+		ChannelType: 2,
+		Payload:     []byte(`{"type":1,"content":"ok"}`),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal MsgSendReq: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal MsgSendReq JSON: %v", err)
+	}
+	if got := payload["client_msg_no"]; got != req.ClientMsgNo {
+		t.Fatalf("client_msg_no = %v, want %q", got, req.ClientMsgNo)
+	}
+}
+
+func TestMsgSendReqClientMsgNoOmittedWhenEmpty(t *testing.T) {
+	data, err := json.Marshal(MsgSendReq{})
+	if err != nil {
+		t.Fatalf("marshal MsgSendReq: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal MsgSendReq JSON: %v", err)
+	}
+	if _, exists := payload["client_msg_no"]; exists {
+		t.Fatalf("client_msg_no should be omitted when empty: %s", data)
+	}
+}
+
+func TestSendMessageWithResultForwardsClientMsgNo(t *testing.T) {
+	const clientMsgNo = "hall_reply_retry_stable"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		defer request.Body.Close()
+		var body map[string]interface{}
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			writer.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if body["client_msg_no"] != clientMsgNo {
+			t.Errorf("client_msg_no = %v, want %q", body["client_msg_no"], clientMsgNo)
+		}
+		writer.Header().Set("content-type", "application/json")
+		_, _ = writer.Write([]byte(`{"data":{"message_id":101,"message_seq":7,"client_msg_no":"hall_reply_retry_stable"}}`))
+	}))
+	defer server.Close()
+
+	cfg := New()
+	cfg.WuKongIM.APIURL = server.URL
+	result, err := (&Context{cfg: cfg}).SendMessageWithResult(&MsgSendReq{
+		ClientMsgNo: clientMsgNo, FromUID: "robot", ChannelID: "group", ChannelType: 2,
+		Payload: []byte(`{"type":1,"content":"ok"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MessageID != 101 || result.MessageSeq != 7 || result.ClientMsgNo != clientMsgNo {
+		t.Fatalf("unexpected send result: %+v", result)
+	}
 }


### PR DESCRIPTION
## 背景

`MsgSendReq` 当前没有暴露 WuKongIM `/message/send` 接口支持的
`client_msg_no` 字段。

调用方在消息发送失败后进行重试时，需要保持同一个客户端消息编号，
以便进行消息幂等控制、重试追踪和发送结果关联。

## 修改内容

- 在 `config.MsgSendReq` 中增加：

  ```go
  ClientMsgNo string `json:"client_msg_no,omitempty"`