### PR TITLE
feat: 支持配置Redis数据库编号(db.redisDB)

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -12,10 +12,10 @@ type RedisCache struct {
 	conn *redis.Conn
 }
 
-// NewRedisCache 创建
-func NewRedisCache(addr string, password string) *RedisCache {
+// NewRedisCache 创建,db为redis数据库编号(0-15),不传默认为0
+func NewRedisCache(addr string, password string, db ...int) *RedisCache {
 	r := &RedisCache{}
-	r.conn = redis.New(addr, password)
+	r.conn = redis.New(addr, password, db...)
 	return r
 }
 

--- a/config/asynctask.go
+++ b/config/asynctask.go
@@ -35,8 +35,8 @@ func NewAsyncTask(cfg *Config) *AsyncTask {
 			DelayedTasksPollPeriod: 500,
 		},
 	}
-	broker := redisbroker.NewGR(cnf, []string{cfg.DB.AsynctaskRedisAddr}, 0)
-	backend := redisbackend.NewGR(cnf, []string{cfg.DB.AsynctaskRedisAddr}, 0)
+	broker := redisbroker.NewGR(cnf, []string{cfg.DB.AsynctaskRedisAddr}, cfg.DB.RedisDB)
+	backend := redisbackend.NewGR(cnf, []string{cfg.DB.AsynctaskRedisAddr}, cfg.DB.RedisDB)
 	lock := eagerlock.New()
 
 	t := &AsyncTask{

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,7 @@ type Config struct {
 		Migration            bool          // 是否合并数据库
 		RedisAddr            string        // redis地址
 		RedisPass            string        // redis密码
+		RedisDB              int           // redis数据库编号(0-15),默认0
 		AsynctaskRedisAddr   string        // 异步任务的redis地址 不写默认为RedisAddr的地址
 	}
 	// ---------- 分布式配置 ----------
@@ -323,6 +324,7 @@ func New() *Config {
 			Migration            bool
 			RedisAddr            string
 			RedisPass            string
+			RedisDB              int
 			AsynctaskRedisAddr   string
 		}{
 			MySQLAddr:            "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true",
@@ -331,6 +333,7 @@ func New() *Config {
 			MySQLConnMaxLifetime: time.Second * 60 * 60 * 4, //mysql 默认超时时间为 60*60*8=28800 SetConnMaxLifetime设置为小于数据库超时时间即可
 			Migration:            true,
 			RedisAddr:            "127.0.0.1:6379",
+			RedisDB:              0,
 		},
 		// ---------- 分布式配置 ----------
 		Cluster: struct {
@@ -587,6 +590,7 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	c.DB.Migration = c.getBool("db.migration", c.DB.Migration)
 	c.DB.RedisAddr = c.getString("db.redisAddr", c.DB.RedisAddr)
 	c.DB.RedisPass = c.getString("db.redisPass", c.DB.RedisPass)
+	c.DB.RedisDB = c.getInt("db.redisDB", c.DB.RedisDB)
 	c.DB.AsynctaskRedisAddr = c.getString("db.asynctaskRedisAddr", c.DB.AsynctaskRedisAddr)
 
 	//#################### cluster ####################

--- a/config/context.go
+++ b/config/context.go
@@ -101,7 +101,7 @@ func (c *Context) DB() *dbr.Session {
 // NewRedisCache 创建一个redis缓存
 func (c *Context) NewRedisCache() *common.RedisCache {
 	if c.redisCache == nil {
-		c.redisCache = common.NewRedisCache(c.cfg.DB.RedisAddr, c.cfg.DB.RedisPass)
+		c.redisCache = common.NewRedisCache(c.cfg.DB.RedisAddr, c.cfg.DB.RedisPass, c.cfg.DB.RedisDB)
 	}
 	return c.redisCache
 }

--- a/pkg/db/redis.go
+++ b/pkg/db/redis.go
@@ -2,6 +2,6 @@ package db
 
 import "github.com/TangSengDaoDao/TangSengDaoDaoServerLib/pkg/redis"
 
-func NewRedis(addr string, password string) *redis.Conn {
-	return redis.New(addr, password)
+func NewRedis(addr string, password string, db ...int) *redis.Conn {
+	return redis.New(addr, password, db...)
 }

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -16,12 +16,18 @@ type Conn struct {
 	client *rd.Client
 }
 
-func New(addr string, password string) *Conn {
+// New 创建一个redis连接,db为redis数据库编号(0-15),不传默认为0
+func New(addr string, password string, db ...int) *Conn {
 	c := &Conn{}
+	rdDB := 0
+	if len(db) > 0 {
+		rdDB = db[0]
+	}
 	c.client = rd.NewClient(&rd.Options{
 		Addr:       addr,
 		MaxRetries: 3, // 失败重试次数
 		Password:   password,
+		DB:         rdDB,
 	})
 	return c
 }


### PR DESCRIPTION
## 概述

当前 Redis 客户端（`pkg/redis.New`）固定连接 db0，无法通过配置指定数据库编号。本次改动为 ServerLib 增加 `db.redisDB` 配置项，使主 Redis 缓存与 machinery 异步任务可以连接到指定 db，便于在共享 Redis 实例时与其他业务数据隔离。

## 改动内容

- `config/config.go`：`DB` 结构新增 `RedisDB int` 字段，从 `db.redisDB` 读取（默认 0，向后兼容）
- `pkg/redis/redis.go`：`New()` 增加 variadic `db ...int` 参数，透传给 `rd.Options.DB`
- `pkg/db/redis.go`、`common/cache.go`：`NewRedis()` / `NewRedisCache()` 相应透传 db 参数（variadic，不传保持原行为）
- `config/context.go`：`NewRedisCache` 传入 `c.cfg.DB.RedisDB`
- `config/asynctask.go`：machinery broker/backend 的 `NewGR` 第三个参数（db）由固定 `0` 改为 `cfg.DB.RedisDB`（异步任务与主 Redis 同实例，跟随主库编号）

## 配置示例

```yaml
db:
  redisAddr: "127.0.0.1:6379"
  redisPass: ""
  redisDB: 8   # 新增：Redis 数据库编号(0-15)，不配置默认为 0
```

## 兼容性

- 所有新增参数均为 variadic，不传参时行为与旧版完全一致（默认 db0）
- `RedisDB` 默认值 `0`，已有配置文件无需修改