### PR TITLE
feat(serverlib): 分离运行时启动与数据库迁移

### DIFF
--- a/module/module.go
+++ b/module/module.go
@@ -18,6 +18,10 @@ func Setup(ctx *config.Context) error {
 	// 获取所有模块
 	ms := register.GetModules(ctx)
 
+	// Legacy compatibility path. New applications must execute schema changes
+	// through an explicit migration process and use SetupRuntime for ordinary
+	// service startup. Keep the former behavior here for downstream consumers
+	// that have not yet moved to the explicit lifecycle.
 	// 初始化SQL
 	var sqlfss []*register.SQLFS
 	for _, m := range ms {
@@ -29,6 +33,20 @@ func Setup(ctx *config.Context) error {
 	err := executeSQL(sqlfss, ctx.DB())
 	if err != nil {
 		return err
+	}
+	return setupRuntimeModules(ctx, ms)
+
+}
+
+// SetupRuntime registers APIs and optional tasks only. It must be used by
+// ordinary Server startup so a restart cannot execute schema migration.
+func SetupRuntime(ctx *config.Context) error {
+	return setupRuntimeModules(ctx, register.GetModules(ctx))
+}
+
+func setupRuntimeModules(ctx *config.Context, ms []register.Module) error {
+	if ctx == nil || ctx.GetHttpRoute() == nil {
+		return fmt.Errorf("runtime setup requires an HTTP route")
 	}
 	// 注册api
 	for _, m := range ms {
@@ -48,7 +66,12 @@ func Setup(ctx *config.Context) error {
 		}
 	}
 	return nil
+}
 
+// RegisteredMigrationSource exposes only the SQLFS registry. Calling it does
+// not instantiate modules or create a business runtime context.
+func RegisteredMigrationSource() FileDirMigrationSource {
+	return FileDirMigrationSource{sqlfss: register.GetMigrationSources()}
 }
 
 func Start(ctx *config.Context) error {
@@ -138,9 +161,13 @@ func (f FileDirMigrationSource) findMigrations(fs *register.SQLFS, migrations *[
 				return fmt.Errorf("error while opening %s: %s", info.Name(), err)
 			}
 
-			migration, err := migrate.ParseMigration(info.Name(), file.(io.ReadSeeker))
-			if err != nil {
-				return fmt.Errorf("error while parsing %s: %s", info.Name(), err)
+			migration, parseErr := migrate.ParseMigration(info.Name(), file.(io.ReadSeeker))
+			closeErr := file.Close()
+			if parseErr != nil {
+				return fmt.Errorf("error while parsing %s: %s", info.Name(), parseErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("error while closing %s: %s", info.Name(), closeErr)
 			}
 			*migrations = append(*migrations, migration)
 

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -1,0 +1,41 @@
+package module
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeSetupHasNoMigrationExecutionPath(t *testing.T) {
+	source, err := os.ReadFile("module.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	start := strings.Index(text, "func setupRuntimeModules(")
+	end := strings.Index(text[start:], "// RegisteredMigrationSource")
+	if start < 0 || end < 0 {
+		t.Fatal("SetupRuntime section missing")
+	}
+	section := text[start : start+end]
+	if strings.Contains(section, "executeSQL(") || strings.Contains(section, "RegisteredMigrationSource") {
+		t.Fatal("SetupRuntime must not execute or enumerate schema migrations")
+	}
+}
+
+func TestRegisteredMigrationSourceDoesNotInstantiateModules(t *testing.T) {
+	source, err := os.ReadFile("module.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	start := strings.Index(text, "func RegisteredMigrationSource(")
+	end := strings.Index(text[start:], "func Start(")
+	if start < 0 || end < 0 {
+		t.Fatal("RegisteredMigrationSource section missing")
+	}
+	section := text[start : start+end]
+	if strings.Contains(section, "GetModules(") || strings.Contains(section, "config.Context") {
+		t.Fatal("migration source enumeration must not instantiate runtime modules or contexts")
+	}
+}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -47,6 +47,13 @@ type ModuleFnc func(ctx interface{}) Module
 
 var modules = make([]ModuleFnc, 0)
 
+// migrationSources are registered directly from module init functions. They
+// deliberately do not require a runtime context or construct a Module, so a
+// controlled migration process can enumerate embedded SQL without starting
+// HTTP routes, workers, RTC services, or module constructors.
+var migrationSources = make([]*SQLFS, 0)
+var migrationSourcesMu sync.RWMutex
+
 type IMDatasourceType int
 
 const (
@@ -135,6 +142,39 @@ func NewSQLFS(fs embed.FS) *SQLFS {
 	return &SQLFS{
 		FS: fs,
 	}
+}
+
+// AddMigrationSource registers an embedded SQL source for the explicit
+// migration lifecycle. A nil source has no migration data and is ignored.
+func AddMigrationSource(source *SQLFS) {
+	if source == nil {
+		return
+	}
+	migrationSourcesMu.Lock()
+	migrationSources = append(migrationSources, cloneSQLFS(source))
+	migrationSourcesMu.Unlock()
+}
+
+// GetMigrationSources returns value copies so callers cannot mutate either the
+// registry slice or its SQLFS wrappers. embed.FS is immutable after compile
+// time, so copying its value is sufficient and does not duplicate file data.
+// Unlike GetModules, this function never receives or creates a runtime
+// context and never executes module factories.
+func GetMigrationSources() []*SQLFS {
+	migrationSourcesMu.RLock()
+	defer migrationSourcesMu.RUnlock()
+	sources := make([]*SQLFS, len(migrationSources))
+	for index, source := range migrationSources {
+		sources[index] = cloneSQLFS(source)
+	}
+	return sources
+}
+
+func cloneSQLFS(source *SQLFS) *SQLFS {
+	if source == nil {
+		return nil
+	}
+	return &SQLFS{FS: source.FS}
 }
 
 var once sync.Once

--- a/pkg/register/register_test.go
+++ b/pkg/register/register_test.go
@@ -1,0 +1,69 @@
+package register
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMigrationSourceRegistryReturnsDefensiveCopy(t *testing.T) {
+	source := &SQLFS{}
+	baseline := len(GetMigrationSources())
+	AddMigrationSource(nil)
+	if got := len(GetMigrationSources()); got != baseline {
+		t.Fatalf("nil source changed registry length: got %d want %d", got, baseline)
+	}
+	AddMigrationSource(source)
+	sources := GetMigrationSources()
+	if len(sources) != baseline+1 || sources[len(sources)-1] == source {
+		t.Fatalf("registered source missing: %#v", sources)
+	}
+	sources[len(sources)-1] = nil
+	if got := GetMigrationSources()[baseline]; got == nil || got == source {
+		t.Fatal("caller mutation must not change migration registry")
+	}
+}
+
+func TestMigrationSourceRegistrySupportsConcurrentRegistrationAndReads(t *testing.T) {
+	const writers = 16
+	const readers = 16
+	const readsPerReader = 100
+	baseline := len(GetMigrationSources())
+	var wg sync.WaitGroup
+	for index := 0; index < writers; index++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			AddMigrationSource(&SQLFS{})
+		}()
+	}
+	for index := 0; index < readers; index++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for read := 0; read < readsPerReader; read++ {
+				for _, source := range GetMigrationSources() {
+					if source == nil {
+						t.Errorf("registry returned a nil migration source")
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := len(GetMigrationSources()); got != baseline+writers {
+		t.Fatalf("concurrent registry length=%d want=%d", got, baseline+writers)
+	}
+}
+
+func TestMigrationSourceRegistryNeverInvokesModuleFactory(t *testing.T) {
+	invoked := false
+	AddModule(func(ctx interface{}) Module {
+		invoked = true
+		return Module{Name: "must-not-run-for-migration-registry"}
+	})
+	_ = GetMigrationSources()
+	if invoked {
+		t.Fatal("migration source registry must not instantiate a runtime module")
+	}
+}


### PR DESCRIPTION
## 变更说明

为 EnterpriseIM 提供独立的 migration source 注册与读取能力，使数据库迁移进程无需创建业务运行时上下文、实例化业务模块或启动 HTTP、worker、RTC、消息任务。普通 Server 启动可改用纯运行时 bootstrap，避免重启时隐式执行数据库 migration。

## 修改范围

- ServerLib `pkg/register`：新增线程安全的 migration source registry；注册和读取均复制 `SQLFS` 包装值。
- ServerLib `module`：新增 `SetupRuntime` 与 `RegisteredMigrationSource`。
- 保留原 `Setup` 的 migration + runtime 行为，兼容尚未迁移的下游。
- 迁移文件解析后显式关闭文件句柄。
- 新增 registry 并发、防御性副本与运行时/迁移边界测试。

不包含 EnterpriseIM 核心适配；核心必须等待本 PR 合并并取得精确可解析版本后，才能更新 `go.mod/go.sum`。

## 是否涉及高风险模块

是，涉及数据库 migration 生命周期和 Server 启动边界。

- [ ] 钱包
- [ ] 红包/转账
- [ ] 签到/身份
- [ ] 群发消息

本 PR 不修改以上业务模块，不包含 migration SQL，也不执行任何数据库操作。已使用独立 Codex 安全复审作为当前紧急审查证据；合并仍需单独授权。

## 架构影响

新增两个向后兼容 API：

- `register.AddMigrationSource` / `register.GetMigrationSources`
- `module.SetupRuntime` / `module.RegisteredMigrationSource`

migration registry 不依赖 `config.Context` 或 module factory；legacy `module.Setup` 保持原顺序和行为。registry 使用独立 `sync.RWMutex`，并在写入和读取两侧复制 `SQLFS`，避免并发竞争和外部篡改内部包装对象。

## 数据库变化

无 migration、无 DDL、无 DML、无数据回填、无数据删除。

本 PR 只提供 migration source 的静态注册和运行时生命周期 API，不改变既有 migration 文件名、ID、排序算法或 `gorp_migrations` 历史。

## 测试结果

环境：`go1.26.5 darwin/arm64`

通过：

- `go test ./... -count=1`
- `go test -race ./...`
- `go vet ./...`
- `go test -shuffle=on -count=50 ./pkg/register ./module`
- `git diff --check`

并发回归覆盖 16 个 writer、16 个 reader，每个 reader 读取 100 次；全包 race 通过。

独立安全复审固定快照结论：

- P0 = 0
- P1 = 0
- P2 = 1
- P3 = 1

## 风险说明

- P2：`module/module_test.go` 对关键生命周期边界仍有部分源码字符串扫描，当前实现正确，但未来间接 helper 回归可能漏检；建议后续补行为级可注入测试。
- P3：registry 测试会累积包级全局注册状态，当前动态 baseline、shuffle 50 次和 race 均通过；后续建议引入测试隔离或 `t.Cleanup` 恢复。
- 本 PR 合并前，EnterpriseIM 核心不能引用这些未发布 API；临时 `go.work` 只用于成对开发验证，不能作为交付依赖。

## 回滚方式

在尚无下游引用新 API 时，可直接 revert 本提交，不涉及数据库或数据回滚。

一旦下游核心版本已切换到 `SetupRuntime` / `RegisteredMigrationSource`，回滚 ServerLib 前必须先回滚下游依赖，否则会产生编译失败。数据库 migration 与业务数据不受本 PR 直接影响。

## 关联 Issue/任务

P1-1：为 EnterpriseIM 建立不启动业务运行时的独立 migration bootstrap 与 source registry。

固定提交：`bec90fd9ca9a7674f99a941502797df256836a49`。